### PR TITLE
perf: Optimize SQL string construction

### DIFF
--- a/sql_writing.go
+++ b/sql_writing.go
@@ -49,6 +49,32 @@ func (w wc) TableAlias(tableName, defaultAlias string) string {
 	return defaultAlias
 }
 
+// onelineWriter is a writer that replaces newlines and tabs with spaces,
+// and collapses multiple spaces into a single space.
+type onelineWriter struct {
+	b                *strings.Builder
+	lastCharWasSpace bool
+}
+
+func newOnelineWriter(b *strings.Builder) *onelineWriter {
+	return &onelineWriter{b: b}
+}
+
+func (w *onelineWriter) Write(p []byte) (n int, err error) {
+	for _, b := range p {
+		if b == '\n' || b == '\t' || b == ' ' {
+			if !w.lastCharWasSpace {
+				w.b.WriteByte(' ')
+				w.lastCharWasSpace = true
+			}
+		} else {
+			w.b.WriteByte(b)
+			w.lastCharWasSpace = false
+		}
+	}
+	return len(p), nil
+}
+
 // IndentedSQL returns source with tabs and lines trying to have a formatted view.
 func IndentedSQL(some SQLWriter) string {
 	buf := new(bytes.Buffer)
@@ -58,6 +84,8 @@ func IndentedSQL(some SQLWriter) string {
 
 // SQL returns source as a oneliner without tabs or line ends.
 func SQL(some SQLWriter) string {
-	src := IndentedSQL(some)
-	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(src, "\t", " "), "\n", " "), "  ", " ")
+	var b strings.Builder
+	w := newOnelineWriter(&b)
+	some.SQLOn(NewWriteContext(w))
+	return strings.TrimSpace(b.String())
 }


### PR DESCRIPTION
The `SQL()` function in `sql_writing.go` was inefficiently building the SQL string. It used an intermediate formatted string created with a `bytes.Buffer`, and then performed multiple `strings.ReplaceAll` calls to clean it up.

This change introduces a custom `io.Writer` implementation, `onelineWriter`, that builds the final, single-line SQL string in a single pass. It replaces tabs and newlines with spaces and collapses multiple spaces into one on the fly.

This new approach reduces memory allocations and CPU usage, improving the performance of every query built by the library.