### PR TITLE
Refactor: remove testSQL helper and other unused functions

### DIFF
--- a/access_pgtypes_test.go
+++ b/access_pgtypes_test.go
@@ -9,11 +9,7 @@ import (
 func TestUUID(t *testing.T) {
 	u := new(pgtype.UUID)
 	e := polyFUUID.Equals(*u)
-	if got, want := testSQL(e), "(p1.fuuid = '00000000-0000-0000-0000-000000000000'::uuid)"; got != want {
+	if got, want := SQL(e), "(p1.fuuid = '00000000-0000-0000-0000-000000000000'::uuid)"; got != want {
 		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}
-}
-
-func testSQL(ex SQLExpression) string {
-	return SQL(ex)
 }

--- a/access_test.go
+++ b/access_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestLiteral_String(t *testing.T) {
 	l := newLiteralString("literal")
-	ls := testSQL(l)
+	ls := SQL(l)
 	if got, want := ls, "'literal'"; got != want {
 		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}

--- a/operators_test.go
+++ b/operators_test.go
@@ -4,16 +4,16 @@ import "testing"
 
 func TestTextOperators(t *testing.T) {
 	a := NewTextAccess(ColumnInfo{ti, "col", false, false, false}, nil)
-	if got, want := testSQL(a.Equals("help")), "(t1.col = 'help')"; got != want {
+	if got, want := SQL(a.Equals("help")), "(t1.col = 'help')"; got != want {
 		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}
-	if got, want := testSQL(a.In("a", "b")), "(t1.col IN ('a','b'))"; got != want {
+	if got, want := SQL(a.In("a", "b")), "(t1.col IN ('a','b'))"; got != want {
 		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}
-	if got, want := testSQL(a.Compare("<", "b")), "(t1.col < 'b')"; got != want {
+	if got, want := SQL(a.Compare("<", "b")), "(t1.col < 'b')"; got != want {
 		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}
-	if got, want := testSQL(a.Like("*b")), "(t1.col LIKE '*b')"; got != want {
+	if got, want := SQL(a.Like("*b")), "(t1.col LIKE '*b')"; got != want {
 		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}
 }


### PR DESCRIPTION
The helper function `testSQL` is a simple wrapper around the `SQL` function. This commit removes the helper and replaces all its usages with a direct call to `SQL`.

This commit also confirms that the functions `func (a booleanAccess) SQL() string` and `func (a float64Access) SQL() string` do not exist in the codebase.